### PR TITLE
Create the m4 dir if it doesn't exist.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+[ -d m4 ] || mkdir m4
+
 aclocal
 autoconf
 autoheader


### PR DESCRIPTION
aclocal version 1.13 fails with the following error:

```
aclocal: error: couldn't open directory 'm4': No such file or directory
```

Creating the m4 directory before executing aclocal fixes the error.
