### PR TITLE
Added buffers & cached memory

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -879,8 +879,8 @@ ProcessList_scan( ProcessList * this ) {
 
   this->freeMem = this->pageSize * vm_stat.free_count / 1024;
   this->sharedMem = 0;
-  this->buffersMem = 0;
-  this->cachedMem = 0;
+  this->buffersMem = this->pageSize * vm_stat.wire_count / 1024;
+  this->cachedMem = this->pageSize * vm_stat.inactive_count / 1024;
   this->totalSwap = 0;
   this->freeSwap = 0;
 


### PR DESCRIPTION
Right now, the memory usage on htop is wrong. I did this quick fix a few years ago, and now you can see the buffers and cached memory. I'm sure there is room to improve (check comments on the commit itself) but way better than having one big lying number :)
