### PR TITLE
correct wrongly named env var: HOMERC ==> HTOPRC

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -208,7 +208,7 @@ Settings* Settings_new(ProcessList* pl, Header* header) {
    home = getenv("HOME_ETC");
    if (!home) home = getenv("HOME");
    if (!home) home = "";
-   rcfile = getenv("HOMERC");
+   rcfile = getenv("HTOPRC");
    if (!rcfile)
       this->userSettings = String_cat(home, "/.htoprc");
    else


### PR DESCRIPTION
`HTOPRC` is supposed to hold a cutom path to htop's config file. It's pretty obvious that `HOMERC` is a misprint, and the outcome is pretty annoying: we cannot specify a custom config file path unless we use `HOMERC` instead.