### PR TITLE
Elevate privileges when reading process information

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -784,7 +784,9 @@ ProcessList_getProcesses( ProcessList * this, float period ) {
 
     ki->ki_p = kp;
 
+    elevate_privileges();
     ProcessList_getTaskInfo( ki );
+    drop_privileges();
 
     p = KI_PROC( ki );
     e = KI_EPROC( ki );
@@ -811,8 +813,10 @@ ProcessList_getProcesses( ProcessList * this, float period ) {
 
     process->updated = true;
 
+    elevate_privileges();
     ProcessList_getCmdLine( ki, command_name, sizeof( command_name ),
                             &cmdlen, 0, 1 );
+    drop_privileges();
 
     user_time = ki->tasks_info.user_time;
     time_value_add( &user_time, &ki->times.user_time );

--- a/htop.c
+++ b/htop.c
@@ -31,6 +31,7 @@ in the source distribution for its full text.
 
 #include "config.h"
 #include "debug.h"
+#include "util.h"
 
 //#link m
 
@@ -238,6 +239,8 @@ int main(int argc, char** argv) {
    bool userOnly = false;
    uid_t userId = 0;
    int sortKey = 0;
+
+   drop_privileges();
 
    char *lc_ctype = getenv("LC_CTYPE");
    if(lc_ctype != NULL)

--- a/util.c
+++ b/util.c
@@ -24,12 +24,12 @@ noerr( int rc ) {
 
 void
 drop_privileges() {
-    (void) seteuid(getuid());
+  (void) seteuid(getuid());
 }
 
 void
 elevate_privileges() {
-    (void) seteuid(0);
+  (void) seteuid(0);
 }
 
 /* vim:ts=2:sw=2:sts=2:et:ft=c 

--- a/util.c
+++ b/util.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 void
 die( const char *msg, ... ) {
@@ -19,6 +20,16 @@ void
 noerr( int rc ) {
   if ( rc != 0 )
     die( "error %d", rc );
+}
+
+void
+drop_privileges() {
+    (void) seteuid(getuid());
+}
+
+void
+elevate_privileges() {
+    (void) seteuid(0);
 }
 
 /* vim:ts=2:sw=2:sts=2:et:ft=c 

--- a/util.h
+++ b/util.h
@@ -14,6 +14,12 @@ die( const char *msg, ... );
 void
 noerr( int rc );
 
+void
+drop_privileges();
+
+void
+elevate_privileges();
+
 /* vim:ts=2:sw=2:sts=2:et:ft=c 
  */
 


### PR DESCRIPTION
htop on OS X needs to be the superuser to read information from processes not owned by the current user. If htop doesn't have the necessary privileges, it is unable to read usage stats and the full process command line.

One workaround is to chown the htop binary to `root:wheel` and set the setuid bit on it, to ensure that the effective uid of `htop` processes is always 0 (root), but this is insecure as it allows unprivileged users to renice or send arbitrary signals to any process on the system.

This pull request makes htop drop privileges as soon as it starts and elevate back to root just when it needs to (to grab process info and command lines). Because of the way saved UID works, we can still elevate back to root after dropping privileges. This makes it safe to setuid the htop binary to root, as htop only elevates to root privileges for read operations. At all other times it's running with the privileges of the user that started it.

The downside of this patch + setuid is that it does leak process command lines to unprivileged users, which could be seen as a security issue. I don't think this is too much of a cause for concern as process command lines are readable by unprivileged users on other operating systems such as Linux and are generally treated as world readable.

**Before screenshot:**

![](https://charlie.su/screen_shot_2015_08_18_at_10.17.22_pm-aaf82d3ee4f555.png)

**After screenshot:**

![](https://charlie.su/screen_shot_2015_08_18_at_10.17.46_pm-7a09656350eb72.png)
